### PR TITLE
Add -webkit variant of backdrop-filter

### DIFF
--- a/gui/_window.scss
+++ b/gui/_window.scss
@@ -106,6 +106,7 @@
   }
 
   &.glass {
+    -webkit-backdrop-filter: blur(1.5px);
     backdrop-filter: blur(1.5px);
 
     &::before {


### PR DESCRIPTION
Added a -webkit variant of the backdrop-filter used for glass windows. This should help with compatibility on for example Mobile Safari