### PR TITLE
Some improvements

### DIFF
--- a/gui/_global.scss
+++ b/gui/_global.scss
@@ -29,14 +29,6 @@ h4 {
   font-size: 1.5rem;
 }
 
-a {
-  text-decoration: none;
-}
-
-a:hover {
-  text-decoration: underline;
-}
-
 u {
   text-decoration: none;
   border-bottom: 0.5px solid #222222;
@@ -115,21 +107,47 @@ summary {
 
     &:hover {
       &:vertical {
+        border-color: var(--button-border-color-hovered);
         background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAkAAAAKCAIAAADpZ+PpAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAAEnQAABJ0Ad5mH3gAAADrSURBVChTTc5LboJQGAXguyoCu4ERCzAGlRk7UOwGWIDh0s4M4kxb06RSq/jAB6AxJkJ4lTDrue3AnvyzP+fLId+/yfM8juP7PQmCCOf7B3e+ZD+O40RRVFW12VQUpd3r9U3T2m4OpKoqWZYNwzBZLEqfh0N7NnvfrPcEWlEUWZb9mWF4Ph6D0ylcLbfM5HkeJrhGA2hb15/QXnv+w7RYXsDatjOdvnmrHSnLEizMNE2v11sUXQBCnn98kbquBUGQJAlmq9WB2e3qg4HJdqKkaRql1HGc0WgMcDJ5dd0F24kediZJ8t/ELT69H+8py0CYSIO5AAAAAElFTkSuQmCC")
             no-repeat center,
           linear-gradient(
             to right,
-            var(--button-shade-light-default) 45%,
+            var(--button-face-hover) 45%,
+            var(--button-shade-light-hovered) 45%
+          );
+      }
+  
+      &:horizontal {
+        border-color: var(--button-border-color-hovered);
+        background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAJCAYAAAALpr0TAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAAEnQAABJ0Ad5mH3gAAADcSURBVChTNZBLqoUwEEQrURQUxZGCvy24ACfiityJi7tv8GauQoPxk5tquA2RQ9vVVYk6z9NZaxFFEe77htYazjk8z4MwDIVZ+rourOuKaZrwvi+WZcE8z1BKCbPPCjk4DAO2bRP1OI7wLiL6Mbd7J408z1GWpQwWRYGqqiQG+03TgMu0MacfUN4qANmn8UOv9MjW3sKaSm7iIdOSlziOQ3LScd93aPonSYK6riVLlmVo21aYfVqzND9pmqLrOlGT+76XbcxLZkb19/l3fEP+oF0cx8KMEASBsDEGX2/CgZCHkg+8AAAAAElFTkSuQmCC")
+            no-repeat center,
+          linear-gradient(
+            to bottom,
+            var(--button-face-hover) 45%,
+            var(--button-shade-light-hovered) 45%
+          );
+      }
+    }
+
+    &:active {
+      &:vertical {
+        border-color: var(--button-border-color-active);
+        background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAkAAAAKCAIAAADpZ+PpAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAAEnQAABJ0Ad5mH3gAAADrSURBVChTTc5LboJQGAXguyoCu4ERCzAGlRk7UOwGWIDh0s4M4kxb06RSq/jAB6AxJkJ4lTDrue3AnvyzP+fLId+/yfM8juP7PQmCCOf7B3e+ZD+O40RRVFW12VQUpd3r9U3T2m4OpKoqWZYNwzBZLEqfh0N7NnvfrPcEWlEUWZb9mWF4Ph6D0ylcLbfM5HkeJrhGA2hb15/QXnv+w7RYXsDatjOdvnmrHSnLEizMNE2v11sUXQBCnn98kbquBUGQJAlmq9WB2e3qg4HJdqKkaRql1HGc0WgMcDJ5dd0F24kediZJ8t/ELT69H+8py0CYSIO5AAAAAElFTkSuQmCC")
+            no-repeat center,
+          linear-gradient(
+            to right,
+            var(--button-face-active) 45%,
             var(--button-shade-light-active) 45%
           );
       }
   
       &:horizontal {
+        border-color: var(--button-border-color-active);
         background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAJCAYAAAALpr0TAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAAEnQAABJ0Ad5mH3gAAADcSURBVChTNZBLqoUwEEQrURQUxZGCvy24ACfiityJi7tv8GauQoPxk5tquA2RQ9vVVYk6z9NZaxFFEe77htYazjk8z4MwDIVZ+rourOuKaZrwvi+WZcE8z1BKCbPPCjk4DAO2bRP1OI7wLiL6Mbd7J408z1GWpQwWRYGqqiQG+03TgMu0MacfUN4qANmn8UOv9MjW3sKaSm7iIdOSlziOQ3LScd93aPonSYK6riVLlmVo21aYfVqzND9pmqLrOlGT+76XbcxLZkb19/l3fEP+oF0cx8KMEASBsDEGX2/CgZCHkg+8AAAAAElFTkSuQmCC")
             no-repeat center,
           linear-gradient(
             to bottom,
-            var(--button-shade-light-default) 45%,
+            var(--button-face-active) 45%,
             var(--button-shade-light-active) 45%
           );
       }
@@ -184,19 +202,77 @@ summary {
         height: 17px;
   
         &:start {
+          border-color: var(--button-border-color-hovered);
           background: url("./icon/button-up.svg"),
                       linear-gradient(
                         to right,
-                        var(--button-shade-light-default) 45%,
+                        var(--button-face-hover) 45%,
+                        var(--button-shade-light-hovered) 45%
+                      );
+        }
+  
+        &:end {
+          border-color: var(--button-border-color-hovered);
+          background: url("./icon/button-down.svg"),
+                      linear-gradient(
+                        to right,
+                        var(--button-face-hover) 45%,
+                        var(--button-shade-light-hovered) 45%
+                      );
+        }
+      }
+  
+      &:horizontal {
+        width: 16px;
+  
+        &:start {
+          border-color: var(--button-border-color-hovered);
+          background: url("./icon/button-left.svg"),
+                      linear-gradient(
+                        to bottom,
+                        var(--button-face-hover) 45%,
+                        var(--button-shade-light-hovered) 45%
+                      );
+        }
+  
+        &:end {
+          border-color: var(--button-border-color-hovered);
+          background: url("./icon/button-right.svg"),
+                      linear-gradient(
+                        to bottom,
+                        var(--button-face-hover) 45%,
+                        var(--button-shade-light-hovered) 45%
+                      );
+        }
+      }
+    }
+
+    &:active {
+      border: var(--button-border);
+      border-color: var(--button-border-color);
+      border-radius: var(--border-radius);
+      box-shadow: var(--button-shadow);
+      background-color: var(--button-face);
+      
+      &:vertical {
+        height: 17px;
+  
+        &:start {
+          border-color: var(--button-border-color-active);
+          background: url("./icon/button-up.svg"),
+                      linear-gradient(
+                        to right,
+                        var(--button-face-active) 45%,
                         var(--button-shade-light-active) 45%
                       );
         }
   
         &:end {
+          border-color: var(--button-border-color-active);
           background: url("./icon/button-down.svg"),
                       linear-gradient(
                         to right,
-                        var(--button-shade-light-default) 45%,
+                        var(--button-face-active) 45%,
                         var(--button-shade-light-active) 45%
                       );
         }
@@ -206,19 +282,21 @@ summary {
         width: 16px;
   
         &:start {
+          border-color: var(--button-border-color-active);
           background: url("./icon/button-left.svg"),
                       linear-gradient(
                         to bottom,
-                        var(--button-shade-light-default) 45%,
+                        var(--button-face-active) 45%,
                         var(--button-shade-light-active) 45%
                       );
         }
   
         &:end {
+          border-color: var(--button-border-color-active);
           background: url("./icon/button-right.svg"),
                       linear-gradient(
                         to bottom,
-                        var(--button-shade-light-default) 45%,
+                        var(--button-face-active) 45%,
                         var(--button-shade-light-active) 45%
                       );
         }

--- a/gui/_global.scss
+++ b/gui/_global.scss
@@ -104,6 +104,28 @@ summary {
           var(--button-shade-dark)
         );
     }
+
+    &:hover {
+      &:vertical {
+        background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAkAAAAKCAIAAADpZ+PpAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAAEnQAABJ0Ad5mH3gAAADrSURBVChTTc5LboJQGAXguyoCu4ERCzAGlRk7UOwGWIDh0s4M4kxb06RSq/jAB6AxJkJ4lTDrue3AnvyzP+fLId+/yfM8juP7PQmCCOf7B3e+ZD+O40RRVFW12VQUpd3r9U3T2m4OpKoqWZYNwzBZLEqfh0N7NnvfrPcEWlEUWZb9mWF4Ph6D0ylcLbfM5HkeJrhGA2hb15/QXnv+w7RYXsDatjOdvnmrHSnLEizMNE2v11sUXQBCnn98kbquBUGQJAlmq9WB2e3qg4HJdqKkaRql1HGc0WgMcDJ5dd0F24kediZJ8t/ELT69H+8py0CYSIO5AAAAAElFTkSuQmCC")
+            no-repeat center,
+          linear-gradient(
+            to right,
+            var(--button-shade-light-default) 45%,
+            var(--button-shade-light-active) 45%
+          );
+      }
+  
+      &:horizontal {
+        background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAJCAYAAAALpr0TAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAAEnQAABJ0Ad5mH3gAAADcSURBVChTNZBLqoUwEEQrURQUxZGCvy24ACfiityJi7tv8GauQoPxk5tquA2RQ9vVVYk6z9NZaxFFEe77htYazjk8z4MwDIVZ+rourOuKaZrwvi+WZcE8z1BKCbPPCjk4DAO2bRP1OI7wLiL6Mbd7J408z1GWpQwWRYGqqiQG+03TgMu0MacfUN4qANmn8UOv9MjW3sKaSm7iIdOSlziOQ3LScd93aPonSYK6riVLlmVo21aYfVqzND9pmqLrOlGT+76XbcxLZkb19/l3fEP+oF0cx8KMEASBsDEGX2/CgZCHkg+8AAAAAElFTkSuQmCC")
+            no-repeat center,
+          linear-gradient(
+            to bottom,
+            var(--button-shade-light-default) 45%,
+            var(--button-shade-light-active) 45%
+          );
+      }
+    }
   }
   
   &-button:horizontal:start:decrement,
@@ -114,6 +136,12 @@ summary {
   }
 
   &-button {
+    /* Add an invisible border to prevent shifting
+       when hovering the scrollbar buttons */
+    border: var(--button-border);
+    border-color: #0000;
+    border-radius: var(--border-radius);
+
     &:vertical {
       height: 17px;
 
@@ -135,6 +163,58 @@ summary {
 
       &:end {
         background: url("./icon/button-right.svg"), var(--scrollbar-x);
+      }
+    }
+
+    &:hover {
+      border: var(--button-border);
+      border-color: var(--button-border-color);
+      border-radius: var(--border-radius);
+      box-shadow: var(--button-shadow);
+      background-color: var(--button-face);
+      
+      &:vertical {
+        height: 17px;
+  
+        &:start {
+          background: url("./icon/button-up.svg"),
+                      linear-gradient(
+                        to right,
+                        var(--button-shade-light-default) 45%,
+                        var(--button-shade-light-active) 45%
+                      );
+        }
+  
+        &:end {
+          background: url("./icon/button-down.svg"),
+                      linear-gradient(
+                        to right,
+                        var(--button-shade-light-default) 45%,
+                        var(--button-shade-light-active) 45%
+                      );
+        }
+      }
+  
+      &:horizontal {
+        width: 16px;
+  
+        &:start {
+          background: url("./icon/button-left.svg"),
+                      linear-gradient(
+                        to bottom,
+                        var(--button-shade-light-default) 45%,
+                        var(--button-shade-light-active) 45%
+                      );
+        }
+  
+        &:end {
+          background: url("./icon/button-right.svg"),
+                      linear-gradient(
+                        to bottom,
+                        var(--button-shade-light-default) 45%,
+                        var(--button-shade-light-active) 45%
+                      );
+        }
       }
     }
   }

--- a/gui/_global.scss
+++ b/gui/_global.scss
@@ -29,6 +29,14 @@ h4 {
   font-size: 1.5rem;
 }
 
+a {
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 u {
   text-decoration: none;
   border-bottom: 0.5px solid #222222;
@@ -75,7 +83,7 @@ summary {
       background: var(--scrollbar-x);
     }
   }
-  
+
   &-thumb {
     border: var(--button-border);
     border-color: var(--button-border-color);
@@ -140,7 +148,6 @@ summary {
        when hovering the scrollbar buttons */
     border: var(--button-border);
     border-color: #0000;
-    border-radius: var(--border-radius);
 
     &:vertical {
       height: 17px;

--- a/gui/_typography.scss
+++ b/gui/_typography.scss
@@ -7,6 +7,7 @@
 
 a {
   color: var(--link-color);
+  text-decoration: none;
 
   &:focus {
     outline: 1px dotted var(--link-color);
@@ -14,6 +15,7 @@ a {
 
   &:hover {
     color: var(--link-color-hovered);
+    text-decoration: underline;
   }
 }
 

--- a/gui/_window.scss
+++ b/gui/_window.scss
@@ -20,9 +20,9 @@
     var(--window-background-color);
   --control-border-color: rgba(0, 0, 0, 0.3);
   --control-border-radius: 5px;
-  --control-inset-shadow: inset 0 0 0 0.5px rgba(255, 255, 255, 0.8);
+  --control-inset-shadow: inset 0 0 0 1px #eee8;
   --control-background: linear-gradient(
-    rgba(255, 255, 255, 0.3),
+    rgba(255, 255, 255, 0.5),
     rgba(255, 255, 255, 0.3) 45%,
     rgba(0, 0, 0, 0.1) 50%,
     rgba(0, 0, 0, 0.1) 75%,
@@ -274,21 +274,22 @@
       button {
         background: var(--control-background);
         border-color: var(--window-border-color);
+        box-shadow: var(--control-inset-shadow);
 
         &:hover {
+          box-shadow: 0 0 15px #2aceda, var(--control-inset-shadow);
           background: radial-gradient(
-              circle at 50% 100%,
+              circle at bottom,
               #2aceda,
               transparent 60%
             ),
             linear-gradient(#a9d2e8 50%, #196c9b 50%);
-          box-shadow: 0 0 15px #2aceda;
         }
 
         &:active {
-          box-shadow: inset 0 0 0 0.5px #eee, 0 0 15px #2aceda;
+          box-shadow: 0 0 15px #2aceda, var(--control-inset-shadow);
           background: radial-gradient(
-              circle at 50% 100%,
+              circle at bottom,
               #0bfdfa,
               transparent 60%
             ),
@@ -297,17 +298,20 @@
 
         &[aria-label="Close"],
         &.is-close {
-          background-color: #d04a37;
+          background-color: #d04834;
+          box-shadow: var(--control-inset-shadow);
 
           &:hover {
-            filter: contrast(1.3);
-            background-image: var(--control-background);
-            box-shadow: 0 0 15px #d04a37, inset 0 -1px 5px orange;
+            background: var(--control-background),
+                        radial-gradient(circle at 50% 170%, orange 10% 20%, #0000 60%),
+                        linear-gradient(#ee6d56 50%, #d42809 50%);
+            box-shadow: 0 0 15px #e68e75, var(--control-inset-shadow);
           }
 
           &:active {
-            filter: contrast(1.3) brightness(0.7);
-            background-image: var(--control-background);
+            background: var(--control-background),
+                        radial-gradient(circle at 50% 170%, yellow 10% 20%, #0000 60%),
+                        linear-gradient(#b67562 50%, #780c01 50%);
           }
         }
 


### PR DESCRIPTION
## _**What's changed:**_

- Improve window title bar buttons (colours, gradient colours).
- Add rules to highlight the scrollbar thumb and buttons when hovering over it.
- Add rules to style hyperlink.

## _**About the scrollbar buttons**_

The scrollbar buttons in Windows 7 behave like this:
- In normal state, the button is shaded totally flat.
- When hovering over the scrollbar (could be the thumb or the track), the button shades will appear.

Here's a [video](https://www.youtube.com/watch?v=H_41nqXx64g) demonstrating it in case you have no clue what I'm talking about.

The problem is I have no idea how to accomplish this. I know that we can set rules to style other elements when hovering another element ([link 1](https://stackoverflow.com/questions/6910049/on-a-css-hover-event-can-i-change-another-divs-styling), [link 2](https://www.geeksforgeeks.org/how-to-affect-other-elements-when-one-element-is-hovered-in-css/)) but I don't know if it's possible for the scrollbar.