### PR TITLE
Add `top`/`left` to window's `::before` to prevent unexpected behavior

### DIFF
--- a/gui/_window.scss
+++ b/gui/_window.scss
@@ -42,6 +42,8 @@
     content: "";
     position: absolute;
     z-index: -1;
+    top: 0;
+    left: 0;
     width: 100%;
     height: 100%;
     border-radius: var(--window-border-radius);


### PR DESCRIPTION
This should close #68 