### PR TITLE
Avoid overlapping menus

### DIFF
--- a/gui/_menu.scss
+++ b/gui/_menu.scss
@@ -37,7 +37,11 @@ ul {
         background: #3399ff;
         color: #fff;
         outline: none;
-      }
+        &:has(~[role="menuitem"]:hover) {
+          background: transparent;
+          color: inherit;
+        }
+      }      
     }
   }
 
@@ -167,6 +171,11 @@ ul {
       > [role="menu"] {
         display: block;
       }
+      &:has(~[role="menuitem"]:hover) {
+        > [role="menu"] {
+          display: none;
+        }
+      }
     }
 
     &[aria-disabled] {
@@ -203,6 +212,14 @@ ul {
   &.can-hover [role="menuitem"]:hover {
     > [role="menu"] {
       display: block;
+    }
+    ~[role="menuitem"]:focus,
+    ~[role="menuitem"]:focus-within {
+      background: transparent;
+      color: inherit;
+      > [role="menu"] {
+        display: none;
+      }
     }
   }
 }

--- a/gui/_menu.scss
+++ b/gui/_menu.scss
@@ -37,6 +37,11 @@ ul {
         background: #3399ff;
         color: #fff;
         outline: none;
+        ~[role="menuitem"]:focus,
+        ~[role="menuitem"]:focus-within {
+          background: transparent;
+          color: inherit;
+        }
         &:has(~[role="menuitem"]:hover) {
           background: transparent;
           color: inherit;


### PR DESCRIPTION
This pull request uses [progressive enhancement](https://developer.mozilla.org/en-US/docs/Glossary/Progressive_Enhancement) to fix [an issue](https://github.com/khang-nd/7.css/issues/62) in the menus: if one menu is under focus, rollover in the next or previous menus provokes an overlaping. To fix this, the [:has() peseudo class](https://developer.mozilla.org/en-US/docs/Web/CSS/:has) and the [general sibling combinator](https://developer.mozilla.org/en-US/docs/Web/CSS/General_sibling_combinator) have been used.

### Notes

1. `:has()` peseudo selector is supported by [87.03% of the global browsers usage](https://caniuse.com/css-has) and `general sibling combinator` is supported by [95.78% of the global browser usage](https://caniuse.com/mdn-css_selectors_general_sibling).
2. These selectors are not supported at all on Internet Explorer, so these rules will be completely ignored in these browsers, therefore the current behaviour is maintained.
3. At the present time, Firefox still doesn‘t support the `:has()` pseudo class. [They are working actively on it](https://connect.mozilla.org/t5/ideas/when-is-has-css-selector-going-to-be-fully-implemented-in/idc-p/35597/highlight/true#M20721) and they plan to release it soon, but to support this pseudo selector right now in this browser it is necessary the `layout.css.has-selector` flag. This means that in this browser, at the moment this pull request will fix the bug if one rolls over the menus before the focused menus (general sibling combinator) but it will not work if one rolls over the menus after them (:has() peseudo class).

### Screencasts

#### Current behaviour

![current-behaviour](https://github.com/khang-nd/7.css/assets/3728220/2ebc4160-e55a-4965-ad66-edb8053e021c)

#### Fix in Chrome

![fix-chrome](https://github.com/khang-nd/7.css/assets/3728220/5522874c-1f47-4411-9cee-c9810ac87750)

#### Fix in Safari

![fix-safari](https://github.com/khang-nd/7.css/assets/3728220/1a975374-7fd1-4332-a57d-57d013a9f9d2)

#### Fix in Firefox

![fix-firefox](https://github.com/khang-nd/7.css/assets/3728220/aa3f6ba2-1815-40cb-93fe-9227e1bcc55d)

Closes: #62 