### PR TITLE
Fix font inconsistency

### DIFF
--- a/gui/_global.scss
+++ b/gui/_global.scss
@@ -1,6 +1,6 @@
 body {
-  font-family: Arial;
-  font-size: 12px;
+  font-family: "Segoe UI", "SegoeUI", "Noto Sans", sans-serif;
+  font-size: 9pt;
   color: #222222;
 }
 

--- a/gui/_typography.scss
+++ b/gui/_typography.scss
@@ -36,7 +36,7 @@ a {
   font-weight: normal;
 
   &-document {
-    font-family: "Calibri";
+    font-family: "Calibri", "Noto Sans", sans-serif;
     font-size: 17pt;
     color: var(--secondary-color);  
   }

--- a/gui/_variables.scss
+++ b/gui/_variables.scss
@@ -1,5 +1,5 @@
 :root {
-  --font: 9pt "Segoe UI", sans-serif;
+  --font: 9pt "Segoe UI", "SegoeUI", "Noto Sans", sans-serif;
   --surface: #f0f0f0;
 
   --button-highlight: #fff;


### PR DESCRIPTION
At https://khang-nd.github.io/7.css/, the left side panel uses Segoe UI while the text on the right is Arial so I changed them all to Segoe UI, which is the main font used in Windows 7 UI (although the new Segoe UI font is no longer the same as the one in Windows 7)
Windows 7's Segoe UI | Windows 10's Segoe UI
:-:|:-:
![SegoeUI-win7](https://github.com/khang-nd/7.css/assets/20926690/f9f9c8f8-2f8d-4b96-b4cf-56c6ff8d90d9) | ![SegoeUI-win10](https://github.com/khang-nd/7.css/assets/20926690/7f21d146-f93b-4b50-974f-81b1a02b36de)

Additionally, for non-Windows platforms, i.e. Linux, Android, etc. which don't have the Segoe UI font family, I added rules to use the Noto Sans instead, which closely resembles the Segoe UI font family.

Noto Sans | Windows 7's Segoe UI
:-:|:-:
![NotoSans](https://github.com/khang-nd/7.css/assets/20926690/9aeb9059-0f9a-44e6-96df-a7a3fc972599) | ![SegoeUI-win7](https://github.com/khang-nd/7.css/assets/20926690/f9f9c8f8-2f8d-4b96-b4cf-56c6ff8d90d9)
