### PR TITLE
Add Noto Sans from Google Fonts

### DIFF
--- a/gui/_global.scss
+++ b/gui/_global.scss
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans&display=swap');
+
 body {
   font-family: "Segoe UI", "SegoeUI", "Noto Sans", sans-serif;
   font-size: 9pt;


### PR DESCRIPTION
Apparently, the Noto Sans font family is not always available on all Linux and Android distros so it needs to be imported from Google Fonts. And hopefully, it'll work everywhere.

Oops! 😅

I don't know if I should put the `@import` rule in the `_global.scss`  or the `_typography.scss` file. I ended up putting it in the `_global.scss` file and it worked just fine the last time I checked, I think 😅.