### PR TITLE
Add animations for the push button and fix focus outline

### DIFF
--- a/gui/_button.scss
+++ b/gui/_button.scss
@@ -58,6 +58,7 @@ button,
   }
 
   &:not(:disabled) {
+    /* Animation when hovered */
     &:hover {
       border-color: var(--button-border-color-hovered);
       transition: border-color .3s;
@@ -65,6 +66,17 @@ button,
       &::before {
         opacity: 1;
         transition: opacity .3s;
+      }
+    }
+
+    /* Animation when unhovered */
+    &:not(:hover) {
+      border-color: var(--button-border-color);
+      transition: border-color 1s linear;
+
+      &::before {
+        opacity: 0;
+        transition: opacity 1s linear;
       }
     }
 
@@ -83,17 +95,22 @@ button,
   &:focus-visible,
   &.focused {
     box-shadow: inset 0 0 0 2px var(--button-shade-light-active);
-    outline: 1px dotted #000000;
+    outline: 1px dotted #000;
     outline-offset: -4px;
   }
 
-  &.default {
-    box-shadow: inset 0 0 0 1px #34deff;
+  &.default, &:focus, &.focused {
     border-color: var(--button-border-color-default);
-    background: linear-gradient(
-      to bottom,
-      var(--button-face) 45%,
-      var(--button-shade-light-default) 45%
-    );
+    background-image: var(--button-gradient-hovered);
+    animation: 1s ease infinite alternate pulse-anim;
+  }
+}
+
+@keyframes pulse-anim {
+  from {
+    box-shadow: inset 0 0 3px 1px #34deffdd;
+  }
+  to {
+    box-shadow: inset 0 0 1px 1px #34deffdd;
   }
 }

--- a/gui/_button.scss
+++ b/gui/_button.scss
@@ -12,6 +12,44 @@ button,
   padding: 0 12px;
   text-align: center;
   background: var(--button-gradient);
+  position: relative;
+  z-index: 0;
+
+  /* Button style on hovered */
+  &::before {
+    content: '';
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    padding: 0;
+    margin: 0;
+    top: 0;
+    left: 0;
+    border-radius: var(--border-radius);
+    box-shadow: var(--button-shadow);
+    background: var(--button-gradient-hovered);
+    opacity: 0;
+    transition: opacity .3s;
+    z-index: -1;
+  }
+
+  /* Button style on clicked */
+  &::after {
+    content: '';
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    padding: 0;
+    margin: 0;
+    top: 0;
+    left: 0;
+    box-shadow: var(--button-shadow-active);
+    border-radius: 2px;
+    background: var(--button-gradient-active);
+    opacity: 0;
+    transition: opacity .3s;
+    z-index: -1;
+  }
 
   &:disabled {
     background: var(--button-face-disabled);
@@ -22,18 +60,27 @@ button,
   &:not(:disabled) {
     &:hover {
       border-color: var(--button-border-color-hovered);
-      background: var(--button-gradient-hovered);
+      transition: border-color .3s;
+      
+      &::before {
+        opacity: 1;
+        transition: opacity .3s;
+      }
     }
 
     &:active,
     &.active {
-      box-shadow: var(--button-shadow-active);
       border-color: var(--button-border-color-active);
-      background: var(--button-gradient-active);
+      transition: border-color .3s;
+
+      &::after {
+        opacity: 1;
+        transition: opacity .3s;
+      }
     }
   }
 
-  &:focus,
+  &:focus-visible,
   &.focused {
     box-shadow: inset 0 0 0 2px var(--button-shade-light-active);
     outline: 1px dotted #000000;

--- a/gui/_checkbox.scss
+++ b/gui/_checkbox.scss
@@ -47,9 +47,9 @@ input[type="checkbox"] {
     }
   }
 
-  &:focus {
+  &:focus-visible {
     + label {
-      outline: 1px dotted #000000;
+      outline: 1px dotted #000;
     }
   }
 

--- a/gui/_combobox.scss
+++ b/gui/_combobox.scss
@@ -18,15 +18,21 @@
     min-width: 16px;
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
+    background: url("icon/button-down.svg") center no-repeat,
+                var(--button-gradient);
 
     &::before {
-      content: "";
-      position: absolute;
-      top: calc(50% - var(--combobox-chevron-size) / 4);
-      left: calc(50% - var(--combobox-chevron-size));
-      border: var(--combobox-chevron-size) solid transparent;
-      border-top-color: #000;
-      border-radius: 2px;
+      border-top-left-radius: 0;
+      border-bottom-left-radius: 0;
+      background: url("icon/button-down.svg") center no-repeat,
+                  var(--button-gradient-hovered);
+    }
+
+    &::after {
+      border-top-left-radius: 0;
+      border-bottom-left-radius: 0;
+      background: url("icon/button-down.svg") center no-repeat,
+                  var(--button-gradient-active);
     }
 
     &:focus {

--- a/gui/_dropdown.scss
+++ b/gui/_dropdown.scss
@@ -19,7 +19,7 @@ select:not([multiple]) {
   &:hover {
     border-color: var(--button-border-color-hovered);
     background-image: url("./icon/button-down.svg"),
-      var(--button-gradient-hovered);
+                      var(--button-gradient-hovered);
   }
 
   &:active {
@@ -27,11 +27,17 @@ select:not([multiple]) {
     border-color: var(--button-border-color-active);
     box-shadow: var(--button-shadow-active);
     background-image: url("./icon/button-down.svg"),
-      var(--button-gradient-active);
+                      var(--button-gradient-active);
   }
 
   &:focus {
     outline: none;
-    /* box-shadow: inset 0 0 0 2px var(--button-shade-light-active); */
   }
+
+  /* focus-visible seems to not work with <select> */
+  /* &:focus-visible {
+    outline: 1px dotted #000;
+    outline-offset: -4px;
+    box-shadow: inset 0 0 0 2px var(--button-shade-light-active);
+  } */
 }

--- a/gui/_global.scss
+++ b/gui/_global.scss
@@ -45,7 +45,7 @@ pre {
 }
 
 summary {
-  &:focus {
-    outline: 1px dotted #000000;
+  &:focus-visible {
+    outline: 1px dotted #000;
   }
 }

--- a/gui/_menu.scss
+++ b/gui/_menu.scss
@@ -3,9 +3,9 @@
   --item-offset-left: 30px;
   --item-hover-background: linear-gradient(
     to bottom,
-    rgba(255, 255, 255, 0.6),
-    rgba(230, 236, 245, 0.8) 90%,
-    rgba(255, 255, 255, 0.8)
+    #fff9,
+    #e6ecf5cc 90%,
+    #fffc
   );
 }
 
@@ -99,9 +99,16 @@ ul {
         white-space: nowrap;
 
         &:hover,
-        &:focus {
+        &:focus-visible {
           background: var(--item-hover-background);
           border-color: #b8d6fb;
+        }
+      }
+
+      > button {
+        &:hover::before,
+        &::after {
+          content: none;
         }
       }
 
@@ -196,7 +203,7 @@ ul {
         margin: 3px 0 2px;
         height: 2px;
         margin-left: var(--item-offset-left);
-        box-shadow: inset 0 1px rgba(0, 0, 0, 0.15), inset 0 -1px #fff;
+        box-shadow: inset 0 1px #00000026, inset 0 -1px #fff;
       }
     }
 

--- a/gui/_radiobutton.scss
+++ b/gui/_radiobutton.scss
@@ -75,7 +75,7 @@ input[type="radio"] {
     }
   }
 
-  &:focus {
+  &:focus-visible {
     + label {
       outline: 1px dotted #000000;
     }

--- a/gui/_searchbox.scss
+++ b/gui/_searchbox.scss
@@ -43,15 +43,21 @@
       background: var(--search-button), var(--button-gradient);
       background-size: 14px;
 
-      &:hover {
+      &::before {
         background: var(--search-button), var(--button-gradient-hovered);
         background-size: 14px;
+        border-radius: 0;
       }
 
-      &:active {
+      &::after {
         background: var(--search-button), var(--button-gradient-active);
         background-size: 14px;
-        box-shadow: inset 1px 1px 2px #37698f;
+        border-radius: 0;
+      }
+
+      &:focus-visible {
+        outline: 1px dotted #000;
+        outline-offset: -4px;
       }
     }
   }

--- a/gui/_slider.scss
+++ b/gui/_slider.scss
@@ -13,9 +13,10 @@ input[type="range"] {
   appearance: none;
   width: 100%;
   background: transparent;
+  padding: 10px 1px;
 
-  &:focus {
-    outline: none;
+  &:focus-visible {
+    outline: 1px dotted #000;
   }
 
   &::-webkit-slider-thumb {

--- a/gui/_tabs.scss
+++ b/gui/_tabs.scss
@@ -1,5 +1,6 @@
 :root {
   --tab-border: 1px solid #888;
+  --tab-border-color: #888;
   --tab-bg: #fff;
 }
 
@@ -33,11 +34,33 @@ menu[role="tablist"] {
       border-bottom: 0;
       position: relative;
       z-index: 8;
+
+      &::before,
+      &::after {
+        content: none;
+      }
+
+      &:hover {
+        border-color: var(--tab-border-color);
+      }
+
+      &:focus, &:active, &.active {
+        border-color: var(--tab-border-color);
+        animation: none;
+      }
+
+      &:focus-visible {
+        outline: 1px dotted #222;
+        outline-offset: -4px;
+      }
     }
 
-    &:focus {
-      outline: 1px dotted #222;
-      outline-offset: -4px;
+    &::before {
+      border-radius: 0;
+    }
+
+    &::after {
+      content: none;
     }
 
     &:disabled {

--- a/gui/_typography.scss
+++ b/gui/_typography.scss
@@ -9,11 +9,11 @@ a {
   color: var(--link-color);
   text-decoration: none;
 
-  &:focus {
+  &:focus-visible {
     outline: 1px dotted var(--link-color);
   }
 
-  &:hover {
+  &:hover, &:focus {
     color: var(--link-color-hovered);
     text-decoration: underline;
   }

--- a/gui/_variables.scss
+++ b/gui/_variables.scss
@@ -12,9 +12,8 @@
   --button-shade-light-hovered: #bee6fd;
   --button-shade-light-active: #98d1ef;
   --button-shade-dark: #cfcfcf;
-  --button-shadow: inset 0 0 0 1px #ffffffcc,
-    inset 0 1px 1px #fff;
-  --button-shadow-active: inset 1px 1px 0 #9eb0ba8f, inset -1px 1px 0 #9eb0ba8f;
+  --button-shadow: inset 0 0 0 1px #fffc;
+  --button-shadow-active: inset 1px 1px 0 #0003, inset -1px 1px 0 #0003;
   --button-border: 1px solid;
   --button-border-color: #8e8f8f;
   --button-border-color-default: #5586a3;

--- a/gui/_variables.scss
+++ b/gui/_variables.scss
@@ -13,7 +13,7 @@
   --button-shade-light-active: #98d1ef;
   --button-shade-dark: #cfcfcf;
   --button-shadow: inset 0 0 0 1px #fffc;
-  --button-shadow-active: inset 1px 1px 0 #0003, inset -1px 1px 0 #0003;
+  --button-shadow-active: inset 1px 1px 0 #0003, inset -1px 1px 0 #0001;
   --button-border: 1px solid;
   --button-border-color: #8e8f8f;
   --button-border-color-default: #5586a3;

--- a/gui/_window.scss
+++ b/gui/_window.scss
@@ -23,7 +23,7 @@
 
   --control-border-color: rgba(0, 0, 0, 0.3);
   --control-border-radius: 5px;
-  --control-inset-shadow: inset 0 0 0 1px #eee8;
+  --control-inset-shadow: inset 0 0 0 1px #fffa;
   --control-background: linear-gradient(
     rgba(255, 255, 255, 0.5),
     rgba(255, 255, 255, 0.3) 45%,
@@ -210,12 +210,12 @@
 
   &-controls {
     display: flex;
-    background: rgba(255, 255, 255, 0.2);
+    background: #fff3;
     border: var(--window-border) var(--control-border-color);
     border-top: 0;
     border-radius: 0 0 var(--control-border-radius) var(--control-border-radius);
     margin-top: -var(--window-spacing);
-    box-shadow: 0 1px 0 #fff9, 1px 0 0 #fff9, -1px 0 0 #fff9;
+    box-shadow: 0 1px 0 #fffa, 1px 0 0 #fffa, -1px 0 0 #fffa;
 
     button {
       position: relative;
@@ -225,16 +225,18 @@
       border: 0;
       border-right: var(--window-border) var(--control-border-color);
       border-radius: 0;
-      box-shadow: var(--control-inset-shadow);
+      box-shadow: none;
       box-sizing: border-box;
       background: none;
+
+      &::after {
+        content: none;
+      }
 
       &:hover,
       &:active {
         /* resolve the conflict with button styles */
         background: none;
-        border-color: var(--control-border-color);
-        box-shadow: var(--control-inset-shadow);
       }
 
       &:disabled {
@@ -250,6 +252,14 @@
         bottom: 0;
         left: 0;
         right: 0;
+        border-radius: 0;
+        box-shadow: inset 0 0 0 1px #fff5;
+        opacity: 1;
+      }
+
+      &:not(:hover)::before {
+        transition: none;
+        opacity: 1;
       }
 
       &[aria-label="Minimize"],
@@ -282,17 +292,18 @@
         }
       }
 
-      &:first-child {
+      &:first-child, &:first-child::before {
         border-bottom-left-radius: var(--control-border-radius);
       }
 
-      &:last-child {
+      &:last-child, &:last-child::before {
         border: 0;
         border-bottom-right-radius: var(--control-border-radius);
       }
 
       &:focus {
         outline: none;
+        animation: none;
       }
     }
   }
@@ -306,6 +317,10 @@
       button {
         border-color: var(--window-border-color);
         box-shadow: var(--control-inset-shadow);
+
+        &::after {
+          content: none;
+        }
 
         &[aria-label="Minimize"],
         &.is-minimize {
@@ -321,7 +336,8 @@
             transition: opacity .3s linear;
           }
 
-          &:hover::before {
+          &:hover::before,
+          &:focus-visible::before {
             opacity: 1;
             transition: opacity .1s linear;
           }
@@ -345,7 +361,8 @@
             transition: opacity .3s linear;
           }
 
-          &:hover::before {
+          &:hover::before,
+          &:focus-visible::before {
             opacity: 1;
             transition: opacity .1s linear;
           }
@@ -369,7 +386,8 @@
             transition: opacity .3s linear;
           }
 
-          &:hover::before {
+          &:hover::before,
+          &:focus-visible::before {
             opacity: 1;
             transition: opacity .1s linear;
           }
@@ -398,7 +416,8 @@
             transition: opacity .3s linear;
           }
 
-          &:hover::before {
+          &:hover::before,
+          &:focus-visible::before {
             opacity: 1;
             transition: opacity .1s linear;
           }


### PR DESCRIPTION
## What's changed:
- Add animations for the push button. It will now fade in and out nicely when hovered or clicked. The animations are also "automagically" applied for other components that use the `<button>` (i.e. combo box, search box, tab).
- Fix #83.
- Various small fixes and adjustments.