### PR TITLE
Allow for dynamic window colour with inline CSS variables

### DIFF
--- a/build.js
+++ b/build.js
@@ -12,9 +12,6 @@ const plugins = [
   require("autoprefixer"),
   require("postcss-import"),
   require("postcss-nested"),
-  require("postcss-css-variables")({
-    preserve: true
-  }),
   require("postcss-calc"),
   require("postcss-base64")({
     root: process.cwd() + "/gui",

--- a/build.js
+++ b/build.js
@@ -12,7 +12,9 @@ const plugins = [
   require("autoprefixer"),
   require("postcss-import"),
   require("postcss-nested"),
-  require("postcss-css-variables"),
+  require("postcss-css-variables")({
+    preserve: true
+  }),
   require("postcss-calc"),
   require("postcss-base64")({
     root: process.cwd() + "/gui",

--- a/docs/components/window/frame.ejs
+++ b/docs/components/window/frame.ejs
@@ -37,20 +37,12 @@
     `) %>
 
     <p>
-      If you want to override the default color of the window, you can specify the
-      <code>background-color</code> attribute in the <code>before</code> pseudo element
-      and the <code>title-bar</code> under the same parent class as <code>window</code>.
+      If you want to override the default color of the window, you can redefine the 
+      <code>--window-background-color</code> variable as an inline value of the <code>style</code> attribute.
     </p>
 
     <%- example(`
-      <style>
-        .violet::before,
-        .violet > .title-bar {
-          background-color: #805ba5;
-        }
-      </style>
-
-      <div class="window violet active" style="max-width: 100%; margin: 0 1.5em;">
+      <div class="window active" style="max-width: 100%; margin: 0 1.5em; --window-background-color: #805ba5;">
         <div class="title-bar">
           <div class="title-bar-text">A violet window frame</div>
           <div class="title-bar-controls">
@@ -64,7 +56,7 @@
       </div>
 
       <div class="background">
-        <div class="window violet glass active" style="max-width: 100%">
+        <div class="window glass active" style="max-width: 100%; --window-background-color: #805ba5;">
           <div class="title-bar">
             <div class="title-bar-text">A glass violet window frame</div>
             <div class="title-bar-controls">

--- a/gui/_balloon.scss
+++ b/gui/_balloon.scss
@@ -20,7 +20,7 @@
     background: var(--balloon-tail-top);
     width: var(--balloon-tail-size);
     height: var(--balloon-tail-size);
-    top: -var(--balloon-tail-size);
+    top: calc(var(--balloon-tail-size) * -1);
     left: var(--balloon-tail-offset);
   }
 
@@ -31,7 +31,7 @@
   &.is-top {
     &::before {
       background: var(--balloon-tail-bottom);
-      bottom: -var(--balloon-tail-size);
+      bottom: calc(var(--balloon-tail-size) * -1);
       top: unset;
       transform: scale(-1);
     }

--- a/gui/_radiobutton.scss
+++ b/gui/_radiobutton.scss
@@ -4,9 +4,10 @@
   --radio-total-width-precalc: var(--radio-width) + var(--radio-label-spacing);
   --radio-total-width: calc(var(--radio-total-width-precalc));
   --radio-dot-width: 8px;
-  --radio-dot-top: calc(var(--radio-width) / 2 - var(--radio-dot-width) / 2);
+  --radio-dot-offset: calc(var(--radio-width) / 2);
+  --radio-dot-top: calc(var(--radio-dot-offset) - var(--radio-dot-width) / 2);
   --radio-dot-left: calc(
-    -1 * (var(--radio-total-width-precalc)) + var(--radio-width) / 2 - var(
+    -1 * (var(--radio-total-width)) + var(--radio-width) / 2 - var(
         --radio-dot-width
       ) / 2
   );
@@ -33,7 +34,7 @@ input[type="radio"] {
       content: "";
       position: absolute;
       top: 0;
-      left: calc(-1 * (var(--radio-total-width-precalc)));
+      left: calc(var(--radio-total-width) * -1);
       display: inline-block;
       width: var(--radio-width);
       height: var(--radio-width);

--- a/gui/_slider.scss
+++ b/gui/_slider.scss
@@ -43,7 +43,14 @@ input[type="range"] {
     }
   }
 
-  &::-webkit-slider-runnable-track,
+  &::-webkit-slider-runnable-track {
+    width: 100%;
+    height: 3px;
+    background: var(--surface);
+    box-sizing: border-box;
+    box-shadow: inset 1px 1px 1px #999, inset -1px 0 #999, 0 1px #fff;
+  }
+
   &::-moz-range-track {
     width: 100%;
     height: 3px;

--- a/gui/_treeview.scss
+++ b/gui/_treeview.scss
@@ -34,7 +34,7 @@ ul.tree-view {
     > summary::before {
       content: "\002b";
       top: calc(50% - var(--treeview-square-size) / 2);
-      left: calc(-var(--treeview-square-size) * 2);
+      left: calc(var(--treeview-square-size) * 2 * -1);
       right: unset;
       width: var(--treeview-square-size);
       height: var(--treeview-square-size);

--- a/gui/_window.scss
+++ b/gui/_window.scss
@@ -149,7 +149,7 @@
     }
 
     pre {
-      margin: -var(--window-spacing);
+      margin: calc(var(--window-spacing) * -1);
     }
   }
 
@@ -249,6 +249,7 @@
   border: var(--window-border) var(--window-border-color);
   border-radius: var(--window-border-radius) var(--window-border-radius) 0 0;
   padding: var(--window-spacing);
+  padding-top: 0;
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -259,6 +260,7 @@
     color: #000;
     letter-spacing: 0;
     line-height: 15px;
+    padding-top: var(--window-spacing);
     text-shadow: 0 0 10px #fff, 0 0 10px #fff, 0 0 10px #fff, 0 0 10px #fff,
       0 0 10px #fff, 0 0 10px #fff, 0 0 10px #fff, 0 0 10px #fff;
   }
@@ -269,7 +271,6 @@
     border: var(--window-border) var(--control-border-color);
     border-top: 0;
     border-radius: 0 0 var(--control-border-radius) var(--control-border-radius);
-    margin-top: -var(--window-spacing);
     box-shadow: 0 1px 0 #fffa, 1px 0 0 #fffa, -1px 0 0 #fffa;
 
     button {
@@ -503,7 +504,7 @@
 
 .status-bar {
   margin: var(--window-spacing);
-  margin-top: -var(--window-spacing);
+  margin-top: calc(var(--window-spacing) * -1);
   background: var(--surface);
   border: var(--window-border) var(--window-border-color);
   border-top: 0;

--- a/gui/_window.scss
+++ b/gui/_window.scss
@@ -132,7 +132,8 @@
     height: 100%;
     border-radius: var(--window-border-radius);
     background: linear-gradient(transparent 20%, #ffffffb3 40%, transparent 41%),
-      var(--window-background);
+    var(--window-background);
+    background-color: var(--window-background-color);
     box-shadow: inset 0 0 0 1px #fffd;
   }
 
@@ -252,6 +253,7 @@
   justify-content: space-between;
   align-items: center;
   background: var(--window-background);
+  background-color: var(--window-background-color);
 
   &-text {
     color: #000;

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "postcss": "^8.3.5",
         "postcss-base64": "^0.7.1",
         "postcss-calc": "^7.0.2",
-        "postcss-css-variables": "^0.14.0",
         "postcss-import": "^12.0.1",
         "postcss-nested": "^4.2.1",
         "postcss-prefix-selector": "^1.15.0"
@@ -1179,12 +1178,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true
     },
     "node_modules/extend-shallow": {
       "version": "3.0.2",
@@ -2931,44 +2924,6 @@
       },
       "peerDependencies": {
         "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-css-variables": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/postcss-css-variables/-/postcss-css-variables-0.14.0.tgz",
-      "integrity": "sha512-fEdksFdcvn/vvTddy4KoPDojZt9hQZx3oXHAIgoYJHsnk97ZTP08unM2UAqksiqdytv93415kBwP+c3/jcopyg==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "escape-string-regexp": "^1.0.3",
-        "extend": "^3.0.1",
-        "postcss": "^6.0.8"
-      }
-    },
-    "node_modules/postcss-css-variables/node_modules/postcss": {
-      "version": "6.0.23",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-      "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^2.4.1",
-        "source-map": "^0.6.1",
-        "supports-color": "^5.4.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/postcss-css-variables/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/postcss-discard-comments": {
@@ -5224,12 +5179,6 @@
         }
       }
     },
-    "extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true
-    },
     "extend-shallow": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
@@ -6603,40 +6552,6 @@
       "dev": true,
       "requires": {
         "postcss-value-parser": "^4.2.0"
-      }
-    },
-    "postcss-css-variables": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/postcss-css-variables/-/postcss-css-variables-0.14.0.tgz",
-      "integrity": "sha512-fEdksFdcvn/vvTddy4KoPDojZt9hQZx3oXHAIgoYJHsnk97ZTP08unM2UAqksiqdytv93415kBwP+c3/jcopyg==",
-      "dev": true,
-      "requires": {
-        "balanced-match": "^1.0.0",
-        "escape-string-regexp": "^1.0.3",
-        "extend": "^3.0.1",
-        "postcss": "^6.0.8"
-      },
-      "dependencies": {
-        "postcss": {
-          "version": "6.0.23",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.4.1",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.4.0"
-          }
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
       }
     },
     "postcss-discard-comments": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "7.css",
-  "version": "0.7.0",
+  "version": "0.16.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "7.css",
-      "version": "0.7.0",
+      "version": "0.16.0",
       "license": "MIT",
       "devDependencies": {
         "autoprefixer": "^10.4.8",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "postcss": "^8.3.5",
     "postcss-base64": "^0.7.1",
     "postcss-calc": "^7.0.2",
-    "postcss-css-variables": "^0.14.0",
     "postcss-import": "^12.0.1",
     "postcss-nested": "^4.2.1",
     "postcss-prefix-selector": "^1.15.0"


### PR DESCRIPTION
Hi @khang-nd,

I had a use case where I was wanting to allow for window colours to be dynamically and globally changed by updating the `--window-background-color` variable. I personally wasn't too keen on having to add a `<style>` tag and overwrite the window `::before` pseudo element and `.title-bar` manually ([as seen here](https://khang-nd.github.io/7.css/#glass-frame-color)), so I opted for this method instead. I also wanted to be able to change this colour on the fly through JS, and updating the CSS variable rather than updating the `<style>` element seems more straightforward.

### Changes

- Explicitly set the `--window-background-color` variable as the `background-color` for `.window` and `.title-bar`, allowing for it to be redefined within the inline `style` attribute of each element.
- Changed `postcss-css-variables` to preserve CSS variables. Ideally I would like to set it to explicitly preserve just the `--window-background-color` and allow for all other CSS variables to be converted to their static counterpart as per original functionality, but I don't believe that `postcss-css-variables` allows for this. [There is an open issue in the postcss-css-variables repo asking for this functionality.](https://github.com/MadLittleMods/postcss-css-variables/issues/94) This does now mean that all CSS variables are now non-static. Keen to hear if you have any thoughts on whether there is a better way to approach this.
- Slightly changed a `calc()` used in `_treeview.scss` to work with the above modification to `postcss-css-variables`. The end result of the calculation remains the same as previous.
- Updated the docs to replace the previous `<style>` overwrite to instead set the `--window-background-color` on both windows demonstrating the colour change functionality.

Would love to hear your thoughts on this and whether you had any feedback. Happy to edit my PR if changes are required. Cheers.