### PR TITLE
Add ListView (table) styles

### DIFF
--- a/docs/components/listview.ejs
+++ b/docs/components/listview.ejs
@@ -1,5 +1,5 @@
 <section class="component">
-    <h3 id="list-view">ListView</h3>
+    <h3 id="listview">ListView</h3>
     <div>
         <blockquote>
             With a list view, users can view and interact with a collection of data objects, using either single

--- a/docs/components/listview.ejs
+++ b/docs/components/listview.ejs
@@ -1,0 +1,49 @@
+<section class="component">
+    <h3 id="list-view">ListView</h3>
+    <div>
+        <blockquote>
+            With a list view, users can view and interact with a collection of data objects, using either single
+            selection or multiple selection.
+            <footer>&mdash; <a href="https://learn.microsoft.com/en-us/windows/win32/uxguide/ctrl-list-views">Microsoft
+                    Windows
+                    User Experience - List View</a></footer>
+        </blockquote>
+
+        <%- example(`
+        <table>
+            <thead>
+            <tr>
+                <th>Name</th>
+                <th>Date Taken</th>
+                <th class="highlighted">Tags</th>
+                <th>Size</th>
+                <th>Rating</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
+                <td>Toco Toucan</td>
+                <td>6/24/2005 12:22 PM</td>
+                <td>Sample; Wildlife</td>
+                <td>113 KB</td>
+                <td>* * * * *</td>
+            </tr>
+            <tr>
+                <td>Dock</td>
+                <td>6/22/2005 8:17 PM</td>
+                <td>Sample; Ocean</td>
+                <td>310 KB</td>
+                <td>* * * * *</td>
+            </tr>
+            <tr>
+                <td>Autumn Leaves</td>
+                <td>11/4/2005 6:12 PM</td>
+                <td>Sample; Landscape</td>
+                <td>270 KB</td>
+                <td>* * * * *</td>
+            </tr>
+            </tbody>
+        </table>
+        `) %>
+    </div>
+</section>

--- a/docs/components/listview.ejs
+++ b/docs/components/listview.ejs
@@ -9,13 +9,15 @@
                     User Experience - List View</a></footer>
         </blockquote>
 
+        <p>Currently, the ListView is only implemented as the Details view, which styles tables.</p>
+
         <%- example(`
         <table>
             <thead>
             <tr>
                 <th>Name</th>
                 <th>Date Taken</th>
-                <th class="highlighted">Tags</th>
+                <th class="highlighted indicator">Tags</th>
                 <th>Size</th>
                 <th>Rating</th>
             </tr>
@@ -28,7 +30,7 @@
                 <td>113 KB</td>
                 <td>* * * * *</td>
             </tr>
-            <tr>
+            <tr class="highlighted">
                 <td>Dock</td>
                 <td>6/22/2005 8:17 PM</td>
                 <td>Sample; Ocean</td>
@@ -41,6 +43,65 @@
                 <td>Sample; Landscape</td>
                 <td>270 KB</td>
                 <td>* * * * *</td>
+            </tr>
+            </tbody>
+        </table>
+        `) %>
+
+        <p>Here's another example showcasing advanced usage, for example:</p>
+        <ul>
+            <li>The handling of long text (using the <code>width</code> property of the table to limit the width)</li>
+            <li>Using the <code>has-shadow</code> class to add a shadow to the table</li>
+            <li>Flipping the column header sort indicator by adding the <code>up</code> class</li>
+            <li>Changing text alignment using the <code>text-align</code> property</li>
+            <li>The <code>highlighted</code> column header style without sort indicator (I didn't want to add another table just for that)</li>
+        </ul>
+        <%- example(`
+        <table class="has-shadow" style="width: 460px;">
+            <thead>
+            <tr>
+                <th>Name</th>
+                <th>Original Location</th>
+                <th class="highlighted">Date deleted</th>
+                <th>Size</th>
+                <th class="highlighted indicator up">Type</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
+                <td>contents_files</td>
+                <td>D:\\Users\\user\\Documents\\contents_files</td>
+                <td>3/29/2007 12:00 AM</td>
+                <td style="text-align: right;">4 KB</td>
+                <td>File Folder</td>
+            </tr>
+            <tr>
+                <td>Windows Vista User Experience Guidelines</td>
+                <td>D:\\Users\\user\\Documents\\Windows Vista User Experience Guidelines</td>
+                <td>3/29/2007 12:00 AM</td>
+                <td style="text-align: right;">0 KB</td>
+                <td>File Folder</td>
+            </tr>
+            <tr>
+                <td>AutoRecovery save of Document.asd</td>
+                <td>D:\\Users\\user\\Documents\\AutoRecovery save of Document.asd</td>
+                <td>3/23/2007 12:00 AM</td>
+                <td style="text-align: right;">27 KB</td>
+                <td>ASD File</td>
+            </tr>
+            <tr>
+                <td>AutoRecovery save of Tree Views.asd</td>
+                <td>D:\\Users\\user\\Documents\\AutoRecovery save of Tree Views.asd</td>
+                <td>3/13/2007 12:00 AM</td>
+                <td style="text-align: right;">693 KB</td>
+                <td>ASD File</td>
+            </tr>
+            <tr>
+                <td>contents</td>
+                <td>D:\\Users\\user\\Documents\\contents</td>
+                <td>3/29/2007 12:00 AM</td>
+                <td style="text-align: right;">2 KB</td>
+                <td>HTML Document</td>
             </tr>
             </tbody>
         </table>

--- a/docs/index.html.ejs
+++ b/docs/index.html.ejs
@@ -68,6 +68,7 @@
     <%- include('components/dropdown') -%>
     <%- include('components/groupbox') -%>
     <%- include('components/listbox') -%>
+    <%- include('components/listview') -%>
 
     <h3 id="nav">Navigation</h3>
     <p>

--- a/docs/sections/navigation.ejs
+++ b/docs/sections/navigation.ejs
@@ -20,7 +20,7 @@
           <li><a href="#dropdown">Dropdown</a></li>
           <li><a href="#groupbox">GroupBox</a></li>
           <li><a href="#listbox">ListBox</a></li>
-          <li><a href="#list-view">ListView</a></li>
+          <li><a href="#listview">ListView</a></li>
           <li>
             <details open>
               <summary><a href="#nav">Navigation</a></summary>

--- a/docs/sections/navigation.ejs
+++ b/docs/sections/navigation.ejs
@@ -20,6 +20,7 @@
           <li><a href="#dropdown">Dropdown</a></li>
           <li><a href="#groupbox">GroupBox</a></li>
           <li><a href="#listbox">ListBox</a></li>
+          <li><a href="#list-view">ListView</a></li>
           <li>
             <details open>
               <summary><a href="#nav">Navigation</a></summary>

--- a/gui/_listview.scss
+++ b/gui/_listview.scss
@@ -1,39 +1,39 @@
 :root {
   --listview-chevron-size: 5px;
-  --listview-background: rgb(255,255,255);
+  --listview-background: #ffffff;
   --listview-border: 1px solid;
-  --listview-border-color: rgb(238,238,238);
-  --listview-border-color-header: rgb(215,215,215);
-  --listview-background-bottom: rgb(240,240,240);
-  --listview-background-middle: rgb(250,250,250);
-  --listview-background-top: rgb(255,255,255);
+  --listview-border-color: #eeeeee;
+  --listview-border-color-header: #d7d7d7;
+  --listview-background-bottom: #f0f0f0;
+  --listview-background-middle: #fafafa;
+  --listview-background-top: #ffffff;
   --listview-gradient: linear-gradient(
                   to bottom,
                   var(--listview-background-top) 45%,
                   var(--listview-background-middle) 45%,
                   var(--listview-background-bottom)
   );
-  --listview-border-color-highlight: rgb(170,221,250);
-  --listview-background-bottom-highlight: rgb(218,238,250);
-  --listview-background-top-highlight: rgb(246,251,253);
+  --listview-border-color-highlight: #aaddfa;
+  --listview-background-bottom-highlight: #daeefa;
+  --listview-background-top-highlight: #f6fbfd;
   --listview-gradient-highlight: linear-gradient(
                   to bottom,
                   var(--listview-header-background-top-highlight) 45%,
                   var(--listview-header-background-bottom-highlight)
   );
-  --listview-header-border-color-highlight: rgb(167,216,245);
-  --listview-header-background-bottom-highlight: rgb(217,234,245);
-  --listview-header-background-middle-highlight: rgb(228,240,248);
-  --listview-header-background-top-highlight: rgb(243,249,252);
+  --listview-header-border-color-highlight: #a7d8f5;
+  --listview-header-background-bottom-highlight: #d9eaf5;
+  --listview-header-background-middle-highlight: #e4f0f8;
+  --listview-header-background-top-highlight: #f3f9fc;
   --listview-header-gradient-highlight: linear-gradient(
                   to bottom,
                   var(--listview-header-background-top-highlight) 45%,
                   var(--listview-header-background-middle-highlight) 45%,
                   var(--listview-header-background-bottom-highlight)
   );
-  --listview-header-chevron-color-left: rgb(102,127,145);
-  --listview-header-chevron-color-middle: rgb(144,193,226);
-  --listview-header-chevron-color-right: rgb(204,227,242);
+  --listview-header-chevron-color-left: #667f91;
+  --listview-header-chevron-color-middle: #90c1e2;
+  --listview-header-chevron-color-right: #cce3f2;
   --listview-header-chevron-background: linear-gradient(
                   to bottom right,
                   var(--listview-header-chevron-color-left) 45%,

--- a/gui/_listview.scss
+++ b/gui/_listview.scss
@@ -1,4 +1,5 @@
 :root {
+  --listview-chevron-size: 5px;
   --listview-background: rgb(255,255,255);
   --listview-border: 1px solid;
   --listview-border-color: rgb(238,238,238);
@@ -29,6 +30,15 @@
                   var(--listview-header-background-top-highlight) 45%,
                   var(--listview-header-background-middle-highlight) 45%,
                   var(--listview-header-background-bottom-highlight)
+  );
+  --listview-header-chevron-color-left: rgb(102,127,145);
+  --listview-header-chevron-color-middle: rgb(144,193,226);
+  --listview-header-chevron-color-right: rgb(204,227,242);
+  --listview-header-chevron-background: linear-gradient(
+                  to bottom right,
+                  var(--listview-header-chevron-color-left) 45%,
+                  var(--listview-header-chevron-color-middle) 65%,
+                  var(--listview-header-chevron-color-right)
   );
 }
 
@@ -75,17 +85,17 @@ table {
 
       &.indicator {
         &::before {
-          border: var(--chevron-size) solid transparent;
-          border-left-color: rgb(160,202,231);
-          border-radius: 3px;
           content: "";
           position: absolute;
           right: 50%;
           top: 0;
-          transform: rotateZ(90deg);
+          width: calc(var(--listview-chevron-size) * 1.2);
+          height: var(--listview-chevron-size);
+          background: var(--listview-header-chevron-background);
+          clip-path: polygon(0% 100%, 50% 0%, 100% 100%);
         }
         &.up::before {
-          transform: rotateZ(-90deg) translateX(var(--chevron-size));
+          clip-path: polygon(0% 0%, 50% 100%, 100% 0%);
         }
       }
     }

--- a/gui/_listview.scss
+++ b/gui/_listview.scss
@@ -92,10 +92,10 @@ table {
           width: calc(var(--listview-chevron-size) * 1.2);
           height: var(--listview-chevron-size);
           background: var(--listview-header-chevron-background);
-          clip-path: polygon(0% 100%, 50% 0%, 100% 100%);
+          clip-path: polygon(0% 0%, 50% 100%, 100% 0%);
         }
         &.up::before {
-          clip-path: polygon(0% 0%, 50% 100%, 100% 0%);
+          clip-path: polygon(0% 100%, 50% 0%, 100% 100%);
         }
       }
     }

--- a/gui/_listview.scss
+++ b/gui/_listview.scss
@@ -1,0 +1,116 @@
+:root {
+  --listview-background: rgb(255,255,255);
+  --listview-border: 1px solid;
+  --listview-border-color: rgb(238,238,238);
+  --listview-border-color-header: rgb(215,215,215);
+  --listview-background-bottom: rgb(240,240,240);
+  --listview-background-middle: rgb(250,250,250);
+  --listview-background-top: rgb(255,255,255);
+  --listview-gradient: linear-gradient(
+                  to bottom,
+                  var(--listview-background-top) 45%,
+                  var(--listview-background-middle) 45%,
+                  var(--listview-background-bottom)
+  );
+  --listview-border-color-highlight: rgb(170,221,250);
+  --listview-background-bottom-highlight: rgb(218,238,250);
+  --listview-background-top-highlight: rgb(246,251,253);
+  --listview-gradient-highlight: linear-gradient(
+                  to bottom,
+                  var(--listview-header-background-top-highlight) 45%,
+                  var(--listview-header-background-bottom-highlight)
+  );
+  --listview-header-border-color-highlight: rgb(167,216,245);
+  --listview-header-background-bottom-highlight: rgb(217,234,245);
+  --listview-header-background-middle-highlight: rgb(228,240,248);
+  --listview-header-background-top-highlight: rgb(243,249,252);
+  --listview-header-gradient-highlight: linear-gradient(
+                  to bottom,
+                  var(--listview-header-background-top-highlight) 45%,
+                  var(--listview-header-background-middle-highlight) 45%,
+                  var(--listview-header-background-bottom-highlight)
+  );
+}
+
+table {
+  font: var(--font);
+  background-color: var(--listview-background);
+  border: 1px solid #c0c1cd;
+
+  border-collapse: collapse;
+  position: relative;
+  text-align: left;
+  white-space: nowrap;
+  table-layout: fixed;
+
+  td, th {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  &.has-shadow {
+    box-shadow: 4px 4px 3px -2px #999;
+  }
+
+  > thead > tr > * {
+    background: var(--listview-gradient);
+    border: var(--listview-border) var(--listview-border-color-header);
+    box-sizing: border-box;
+    font-weight: 400;
+    height: 22px;
+    padding: 0 var(--grouped-element-spacing);
+    position: sticky;
+    top: 0;
+    cursor: default;
+
+    &.highlighted {
+      border: var(--listview-border) var(--listview-header-border-color-highlight);
+      background: var(--listview-header-gradient-highlight);
+      border-radius: var(--border-radius);
+
+      &:not(:last-child) {
+        border-right-color: var(--listview-header-border-color-highlight);
+      }
+
+      &.indicator {
+        &::before {
+          border: var(--chevron-size) solid transparent;
+          border-left-color: rgb(160,202,231);
+          border-radius: 3px;
+          content: "";
+          position: absolute;
+          right: 50%;
+          top: 0;
+          transform: rotateZ(90deg);
+        }
+        &.up::before {
+          transform: rotateZ(-90deg) translateX(var(--chevron-size));
+        }
+      }
+    }
+  }
+
+  > tbody > tr {
+    cursor: default;
+
+    &.highlighted {
+      border: var(--listview-border) var(--listview-border-color-highlight);
+      background: var(--listview-gradient-highlight);
+      border-radius: var(--border-radius);
+
+      > *:not(:last-child) {
+        border-right: none;
+      }
+    }
+
+    > * {
+      height: 14px;
+      padding: 2px var(--element-spacing);
+    }
+
+    > *:not(:last-child) {
+      border-right: var(--listview-border) var(--listview-border-color);
+    }
+  }
+}

--- a/gui/index.scss
+++ b/gui/index.scss
@@ -14,6 +14,7 @@
 @import "_dropdown.scss";
 @import "_groupbox.scss";
 @import "_listbox.scss";
+@import "_listview.scss";
 @import "_menu.scss";
 @import "_progressbar.scss";
 @import "_radiobutton.scss";


### PR DESCRIPTION
Hi,

This PR (fixes #73) adds styling for `<table>` elements, which are styled according to the ListView ("Details" mode) styles described in [the MS Windows 7 Design Guidelines](https://learn.microsoft.com/en-us/windows/win32/uxguide/ctrl-list-views).

I left out the icons visible in the Microsoft documentation from the example, since they are probably "All Rights Reserved" by MS.

Thanks for your consideration.