### PR TITLE
Fix summary toggle visibility for treeview and collapse

### DIFF
--- a/gui/_collapse.scss
+++ b/gui/_collapse.scss
@@ -20,6 +20,11 @@ details {
       border-left-color: #000;
       border-radius: 3px;
     }
+
+    &::-webkit-details-marker,
+    &::marker {
+      display: none;
+    }
   }
 
   &[open] {

--- a/gui/_treeview.scss
+++ b/gui/_treeview.scss
@@ -54,7 +54,7 @@ ul.tree-view {
         color: #4b63a7;
         font-size: 8pt;
         font-weight: bold;
-        line-height: 0.5;
+        line-height: calc(var(--treeview-square-size) - calc(50% - var(--treeview-square-size) / 2));
         text-align: center;
         margin: 0;
       }

--- a/gui/_treeview.scss
+++ b/gui/_treeview.scss
@@ -31,26 +31,33 @@ ul.tree-view {
   }
 
   &.has-collapse-button details {
-    > summary::before {
-      content: "\002b";
-      top: calc(50% - var(--treeview-square-size) / 2);
-      left: calc(var(--treeview-square-size) * 2 * -1);
-      right: unset;
-      width: var(--treeview-square-size);
-      height: var(--treeview-square-size);
-      background: linear-gradient(
-        to bottom,
-        var(--button-face) 45%,
-        var(--button-shade-light)
-      );
-      border: 1px solid #919191;
-      border-radius: 1px;
-      color: #4b63a7;
-      font-size: 8pt;
-      font-weight: bold;
-      line-height: 0.5;
-      text-align: center;
-      margin: 0;
+    > summary {
+      &::-webkit-details-marker,
+      &::marker {
+        display: none;
+      }
+
+      &::before {
+        content: "\002b";
+        top: calc(50% - var(--treeview-square-size) / 2);
+        left: calc(var(--treeview-square-size) * 2 * -1);
+        right: unset;
+        width: var(--treeview-square-size);
+        height: var(--treeview-square-size);
+        background: linear-gradient(
+                        to bottom,
+                        var(--button-face) 45%,
+                        var(--button-shade-light)
+        );
+        border: 1px solid #919191;
+        border-radius: 1px;
+        color: #4b63a7;
+        font-size: 8pt;
+        font-weight: bold;
+        line-height: 0.5;
+        text-align: center;
+        margin: 0;
+      }
     }
 
     &[open] > summary::before {


### PR DESCRIPTION
Hi again,

this PR fixes the summary toggle visibility for the collapse and treeview elements, and the line-height calculation for the treeview toggle (to center the symbol).

### Before (duplicated indicators, off-center treeview toggle)
<img width="570" alt="Screenshot 2024-10-29 at 23 32 09" src="https://github.com/user-attachments/assets/127f6e3d-cf50-4721-b9ee-edbb59f2984f">

### After
<img width="723" alt="Screenshot 2024-10-30 at 14 18 39" src="https://github.com/user-attachments/assets/7fdaf5cf-99f8-453d-94ae-4a623fa4bf58">

Thanks
