### PR TITLE
Add ability to toggle glass frame scroll motion

### DIFF
--- a/docs/components/window/frame.ejs
+++ b/docs/components/window/frame.ejs
@@ -72,20 +72,20 @@
     `) %>
 
     <p>
-      To make the aero effect move when scrolling, or changing the viewport size, change the <code>background-attachment</code> property of the <code>.title-bar</code> to <code>fixed</code> or <code>scroll</code>, depending on your requirements.
+      To make the aero effect stick to the window when scrolling, or changing the viewport size, change the <code>background-attachment</code> property of the <code>.title-bar</code> to <code>local</code> or <code>scroll</code> (default is <code>fixed</code>), depending on your requirements.
     </p>
     <%- example(`
       <div class="background">
         <div class="window glass active" style="max-width: 100%">
-          <div class="title-bar" style="background-attachment: fixed;">
-            <div class="title-bar-text">A glass window frame with fixed background-attachment</div>
+          <div class="title-bar" style="background-attachment: local;">
+            <div class="title-bar-text">A glass window frame with local background-attachment</div>
             <div class="title-bar-controls">
               <button aria-label="Minimize"></button>
               <button aria-label="Close"></button>
             </div>
           </div>
           <div class="window-body has-space">
-            <p>The aero effect is now changing with the scroll position.</p>
+            <p>The aero effect is now staying in place with the scroll position.</p>
           </div>
         </div>
       </div>

--- a/docs/components/window/frame.ejs
+++ b/docs/components/window/frame.ejs
@@ -70,4 +70,24 @@
         </div>
       </div>
     `) %>
+
+    <p>
+      In case you need the fixed background behavior, add the <code>fixed-background</code> class to the window (otherwise it uses <code>background-attachment: scroll;</code>).
+    </p>
+    <%- example(`
+      <div class="background">
+        <div class="window glass active fixed-background" style="max-width: 100%">
+          <div class="title-bar">
+            <div class="title-bar-text">A glass window frame</div>
+            <div class="title-bar-controls">
+              <button aria-label="Minimize"></button>
+              <button aria-label="Close"></button>
+            </div>
+          </div>
+          <div class="window-body has-space">
+            <p>The background behind is blurred.</p>
+          </div>
+        </div>
+      </div>
+    `) %>
 </section>

--- a/docs/components/window/frame.ejs
+++ b/docs/components/window/frame.ejs
@@ -72,12 +72,12 @@
     `) %>
 
     <p>
-      In case you need the fixed background attachment, add the <code>fixed-background</code>, and for scrolling attachment <code>scroll-background</code> class to the window (otherwise it uses <code>background-attachment: local;</code>).
+      To make the aero effect move when scrolling, or changing the viewport size, change the <code>background-attachment</code> property of the <code>.title-bar</code> to <code>fixed</code> or <code>scroll</code>, depending on your requirements.
     </p>
     <%- example(`
       <div class="background">
-        <div class="window glass active fixed-background" style="max-width: 100%">
-          <div class="title-bar">
+        <div class="window glass active" style="max-width: 100%">
+          <div class="title-bar" style="background-attachment: fixed;">
             <div class="title-bar-text">A glass window frame with fixed background-attachment</div>
             <div class="title-bar-controls">
               <button aria-label="Minimize"></button>
@@ -85,7 +85,7 @@
             </div>
           </div>
           <div class="window-body has-space">
-            <p>The title bar background is now changing with the scroll state.</p>
+            <p>The aero effect is now changing with the scroll position.</p>
           </div>
         </div>
       </div>

--- a/docs/components/window/frame.ejs
+++ b/docs/components/window/frame.ejs
@@ -72,7 +72,7 @@
     `) %>
 
     <p>
-      In case you need the fixed background behavior, add the <code>fixed-background</code> class to the window (otherwise it uses <code>background-attachment: scroll;</code>).
+      In case you need the fixed background attachment, add the <code>fixed-background</code>, and for scrolling attachment <code>scroll-background</code> class to the window (otherwise it uses <code>background-attachment: local;</code>).
     </p>
     <%- example(`
       <div class="background">

--- a/docs/components/window/frame.ejs
+++ b/docs/components/window/frame.ejs
@@ -78,14 +78,14 @@
       <div class="background">
         <div class="window glass active fixed-background" style="max-width: 100%">
           <div class="title-bar">
-            <div class="title-bar-text">A glass window frame</div>
+            <div class="title-bar-text">A glass window frame with fixed background-attachment</div>
             <div class="title-bar-controls">
               <button aria-label="Minimize"></button>
               <button aria-label="Close"></button>
             </div>
           </div>
           <div class="window-body has-space">
-            <p>The background behind is blurred.</p>
+            <p>The title bar background is now changing with the scroll state.</p>
           </div>
         </div>
       </div>

--- a/gui/_window.scss
+++ b/gui/_window.scss
@@ -213,7 +213,7 @@
 
     > .title-bar {
       background: var(--window-background-glass-stripes);
-      background-attachment: local;
+      background-attachment: fixed;
     }
   }
 

--- a/gui/_window.scss
+++ b/gui/_window.scss
@@ -213,6 +213,13 @@
 
     > .title-bar {
       background: var(--window-background-glass-stripes);
+      background-attachment: fixed;
+    }
+
+    &:not(.fixed-background) {
+      > .title-bar {
+        background-attachment: scroll;
+      }
     }
   }
 

--- a/gui/_window.scss
+++ b/gui/_window.scss
@@ -213,12 +213,12 @@
 
     > .title-bar {
       background: var(--window-background-glass-stripes);
-      background-attachment: fixed;
+      background-attachment: scroll;
     }
 
-    &:not(.fixed-background) {
+    &.fixed-background {
       > .title-bar {
-        background-attachment: scroll;
+        background-attachment: fixed;
       }
     }
   }

--- a/gui/_window.scss
+++ b/gui/_window.scss
@@ -215,18 +215,6 @@
       background: var(--window-background-glass-stripes);
       background-attachment: local;
     }
-
-    &.fixed-background {
-      > .title-bar {
-        background-attachment: fixed;
-      }
-    }
-
-    &.scroll-background {
-      > .title-bar {
-        background-attachment: scroll;
-      }
-    }
   }
 
   > .title-bar {

--- a/gui/_window.scss
+++ b/gui/_window.scss
@@ -213,12 +213,18 @@
 
     > .title-bar {
       background: var(--window-background-glass-stripes);
-      background-attachment: scroll;
+      background-attachment: local;
     }
 
     &.fixed-background {
       > .title-bar {
         background-attachment: fixed;
+      }
+    }
+
+    &.scroll-background {
+      > .title-bar {
+        background-attachment: scroll;
       }
     }
   }


### PR DESCRIPTION
Hi,

This PR changes the default glass background behavior to be non-moving. 
The old behavior can be enabled again by adding a class to the window, I also added another example for this to the documentation (into the "Glass frame & Color" section), so the difference is directly visible.

Thanks