### PR TITLE
fix: use pixelated image rendering for title bar controls

### DIFF
--- a/gui/_window.scss
+++ b/gui/_window.scss
@@ -213,6 +213,7 @@
       box-shadow: none;
       box-sizing: border-box;
       background: none;
+      image-rendering: pixelated;
 
       &::after {
         content: none;


### PR DESCRIPTION
Set `image-rendering: pixelated` for the title bar buttons to avoid blurriness. 

Before:
<img width="796" height="114" alt="image" src="https://github.com/user-attachments/assets/d940b61c-936d-4944-8d72-195fe382f114" />

After: 
<img width="796" height="114" alt="image" src="https://github.com/user-attachments/assets/7079ffb7-33a8-4eec-93ff-bc96e110e0cb" />
